### PR TITLE
ConvertFrom-UserAuthenticationMethod: add Passkey (synced) bit 26

### DIFF
--- a/Helper-Scripts/ConvertFrom-UserAuthenticationMethod.ps1
+++ b/Helper-Scripts/ConvertFrom-UserAuthenticationMethod.ps1
@@ -46,7 +46,7 @@
 .EXAMPLE
   PS> .\ConvertFrom-UserAuthenticationMethod.ps1 -DecimalValue 33554704
 
-  Password Hash Sync + via Staged Rollout + Passkey (FIDO2)
+  Password Hash Sync + via Staged Rollout + Passkey (device-bound)
 
 .NOTES
   Author - Martin Willing
@@ -76,7 +76,8 @@ Begin
         "X.509 Certificate"           = 2097152
         "MacOS Platform Credentials"  = 8388608
         "QR Code PIN"                 = 16777216
-        "Passkey (FIDO2)"             = 33554432
+        "Passkey (device-bound)"      = 33554432
+        "Passkey (synced)"            = 67108864
         "Email Verification Code"     = 134217728
     }
 }


### PR DESCRIPTION
Hi Martin,

First — thanks for wiring our research into this script. As far as I can tell, Microsoft-Analyzer-Suite is the only project that has actually exposed the `UserAuthenticationMethod` bitfield as a tool analysts can run, and we genuinely appreciate it.

I'm opening this PR because we've since identified one more bit and wanted to keep the script in sync with the blog post:

- **Adds bit 26 (`67108864`) = Passkey (synced).** Microsoft declared synced passkeys [generally available in March 2026](https://learn.microsoft.com/en-us/entra/fundamentals/whats-new#general-availability---synced-passkeys-in-microsoft-entra-id); the value started showing up in production UAL logs in late January 2026.
- **Renames bit 25 (`33554432`) from `Passkey (FIDO2)` to `Passkey (device-bound)`** to match Microsoft's current Entra ID taxonomy. Both bits are FIDO2 credentials — Microsoft's distinction is device-bound (FIDO2 security keys, Microsoft Authenticator) vs synced (cloud passkey providers like iCloud Keychain, Google Password Manager, 1Password, Bitwarden). Once bit 26 appeared, keeping bit 25 labelled "FIDO2" was ambiguous. Happy to drop this rename and handle it as a follow-up if you'd prefer — let me know.
- Updates the `33554704` `.EXAMPLE` to match.

## How we verified

Same correlation method as the original blog post: match M365 UAL events to Entra ID sign-in logs via `InterSystemsId` ↔ `correlationId` and read the Entra `authenticationMethodDetail` field. Across 89 sessions where `UserAuthenticationMethod = 67108864`, `Passkey (synced)` was the dominant Entra ID method, and the detail strings named classic synced-passkey providers (Bitwarden, iCloud Keychain, named credential stores on iPhones).

Smoke-tested locally with `pwsh`:

```
  1         -> Password in the Cloud
  33554432  -> Passkey (device-bound)
  67108864  -> Passkey (synced)
  33554704  -> Password Hash Sync + via Staged Rollout + Passkey (device-bound)
```

## Refs
- Blog post (updated 2026-04-11 with the new bit): https://blog.sekoia.io/userauthenticationmethod-microsoft-365-decode/
- Microsoft docs: [Types of passkeys](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-passkeys-fido2#types-of-passkeys)